### PR TITLE
Simplify vm stats summary and add totals window

### DIFF
--- a/summary_vm_stats.py
+++ b/summary_vm_stats.py
@@ -4,10 +4,9 @@ Summarize vm_stats.jsonl with pandas.
 
 - Works with the logger you built (psutil-based):
   * Handles aggregated or per-NIC `net_io_per_sec`
-  * Handles per-mount `nfs_io_per_sec` and `nfs_usage` if present
-  * Handles disk busy% (when available on Linux)
-  * Computes NFS share of total network IO
-- Produces console table + JSON and CSV outputs.
+  * Handles per-mount `nfs_io_per_sec`
+- Produces windowed summary for CPU, memory, swap, net IO and per-mount NFS IO
+- Prints totals and burstiness/cadence metrics for disk, net and NFS throughput.
 
 Requires: pandas, numpy
 Python: 3.9+
@@ -15,7 +14,6 @@ Python: 3.9+
 
 from __future__ import annotations
 import json
-import math
 import sys
 from pathlib import Path
 from typing import Dict, Any, List, Optional, Tuple
@@ -23,6 +21,7 @@ from typing import Dict, Any, List, Optional, Tuple
 import numpy as np
 import pandas as pd
 from datetime import datetime, timezone, timedelta
+import re
 
 # -------------------------
 # CONFIG
@@ -37,13 +36,10 @@ THRESHOLDS = {
     "CPU %": 65.0,
     "Memory %": 50.0,
     "Swap %": 1.0,
-    "Disk busy %": 70.0,
     "Disk read (B/s)": 0.0,
     "Disk write (B/s)": 0.0,
     "Net send (B/s)": 0.0,
     "Net recv (B/s)": 0.0,
-    "NFS read (B/s)": 0.0,
-    "NFS write (B/s)": 0.0,
 }
 
 # -------------------------
@@ -77,10 +73,20 @@ def to_utc(ts: pd.Series) -> pd.Series:
     return t
 
 
-def flatten_columns(df: pd.DataFrame) -> pd.DataFrame:
-    """Flatten nested dict columns and build aggregate series for net/NFS."""
+def sanitize_mount(path: str) -> str:
+    """Return a filesystem-safe slug for mount paths."""
+    slug = re.sub(r"[^A-Za-z0-9]+", "_", path.strip("/"))
+    return slug or "root"
+
+
+def flatten_columns(df: pd.DataFrame) -> tuple[pd.DataFrame, Dict[str, str]]:
+    """Flatten nested dict columns and build aggregate series for net/NFS.
+
+    Returns:
+        (df, nfs_mounts) where nfs_mounts maps slug -> original mount path.
+    """
     if df.empty:
-        return df
+        return df, {}
 
     # --- Parse & index by timestamp
     if "timestamp" in df.columns:
@@ -109,7 +115,6 @@ def flatten_columns(df: pd.DataFrame) -> pd.DataFrame:
         ("swap", "swap"),
         ("disk", "disk"),
         ("disk_io_per_sec", "disk_io_per_sec"),
-        ("load", "load"),
     ]:
         df = flatten_dict_col(df, base, pref)
 
@@ -141,34 +146,26 @@ def flatten_columns(df: pd.DataFrame) -> pd.DataFrame:
             # Column exists but no usable dicts -> drop to avoid confusion
             df = df.drop(columns=["net_io_per_sec"])
 
-    # --- NFS per-mount throughput + capacity (optional fields)
+    # --- NFS per-mount throughput (optional field)
+    nfs_mounts: Dict[str, str] = {}
     if "nfs_io_per_sec" in df.columns:
-        def nfs_sum(d: Any, field: str) -> float:
-            if not isinstance(d, dict):
-                return np.nan
-            return float(sum((row.get(field, 0) or 0) for row in d.values() if isinstance(row, dict)))
-        df["nfs.read_bytes"]  = df["nfs_io_per_sec"].apply(lambda d: nfs_sum(d, "read_bytes"))
-        df["nfs.write_bytes"] = df["nfs_io_per_sec"].apply(lambda d: nfs_sum(d, "write_bytes"))
+        # discover all mount points
+        mounts: set[str] = set()
+        for d in df["nfs_io_per_sec"].dropna():
+            if isinstance(d, dict):
+                mounts.update(d.keys())
+        for mnt in sorted(mounts):
+            slug = sanitize_mount(mnt)
+            nfs_mounts[slug] = mnt
+            df[f"nfs.{slug}.read_bytes"] = df["nfs_io_per_sec"].apply(
+                lambda d, m=mnt: float(d.get(m, {}).get("read_bytes", np.nan)) if isinstance(d, dict) else np.nan
+            )
+            df[f"nfs.{slug}.write_bytes"] = df["nfs_io_per_sec"].apply(
+                lambda d, m=mnt: float(d.get(m, {}).get("write_bytes", np.nan)) if isinstance(d, dict) else np.nan
+            )
         df = df.drop(columns=["nfs_io_per_sec"])
 
-    if "nfs_usage" in df.columns:
-        def nfs_usage_percent_avg(d: Any) -> float:
-            if not isinstance(d, dict):
-                return np.nan
-            vals = [float(x.get("percent", np.nan)) for x in d.values() if isinstance(x, dict)]
-            vals = [v for v in vals if not math.isnan(v)]
-            return float(np.mean(vals)) if vals else np.nan
-        df["nfs.usage_percent_avg"] = df["nfs_usage"].apply(nfs_usage_percent_avg)
-        df = df.drop(columns=["nfs_usage"])
-
-    # --- NFS share of total network IO (percentage)
-    needed_cols = {"net.bytes_sent", "net.bytes_recv", "nfs.read_bytes", "nfs.write_bytes"}
-    if needed_cols.issubset(df.columns):
-        net_tot = df["net.bytes_sent"].fillna(0) + df["net.bytes_recv"].fillna(0)
-        nfs_tot = df["nfs.read_bytes"].fillna(0) + df["nfs.write_bytes"].fillna(0)
-        df["nfs.net_io_pct"] = np.where(net_tot > 0, (nfs_tot / net_tot) * 100.0, np.nan)
-
-    return df
+    return df, nfs_mounts
 
 def estimate_sample_dt(index: pd.DatetimeIndex) -> Optional[float]:
     if index is None or index.size < 2:
@@ -226,47 +223,30 @@ def summarize_series(name: str, s: pd.Series, threshold: Optional[float], sample
         "time_above_pct": tabv, "longest_streak_samples": streak_samples,
         "longest_streak_seconds": streak_seconds,
     }
-
-
-def summarize_throughput(name_prefix: str, s_bps: pd.Series, sample_dt: Optional[float]) -> Dict[str, Any]:
-    """Extra summary for throughput series: total bytes and avg B/s."""
-    x = pd.to_numeric(s_bps, errors="coerce").fillna(0.0).values.astype(float)
-    total_bytes = float(np.sum(x))  # since values are bytes per interval
-    mean_bps = float(np.mean(x)) if x.size else 0.0
-    p95_bps = float(np.percentile(x, 95)) if x.size else 0.0
-    return {
-        f"{name_prefix}_total_bytes": total_bytes,
-        f"{name_prefix}_mean_bps": mean_bps,
-        f"{name_prefix}_p95_bps": p95_bps,
-    }
-
-
 def window_df(df: pd.DataFrame, minutes: Optional[int]) -> pd.DataFrame:
     if df.empty or not isinstance(df.index, pd.DatetimeIndex) or minutes is None:
         return df
     return df.last(f"{minutes}min")
 
 
-def build_metric_map(df: pd.DataFrame) -> List[Tuple[str, str]]:
+def build_metric_map(df: pd.DataFrame, nfs_mounts: Dict[str, str]) -> List[Tuple[str, str]]:
     """(label, column) pairs present in df."""
-    candidates = [
+    base = [
         ("CPU %", "cpu_percent"),
         ("Memory %", "memory.percent"),
         ("Swap %", "swap.percent"),
-        ("Disk busy %", "disk_io_per_sec.busy_percent"),
-        ("Disk read (B/s)", "disk_io_per_sec.read_bytes"),
-        ("Disk write (B/s)", "disk_io_per_sec.write_bytes"),
         ("Net send (B/s)", "net.bytes_sent"),
         ("Net recv (B/s)", "net.bytes_recv"),
-        ("NFS read (B/s)", "nfs.read_bytes"),
-        ("NFS write (B/s)", "nfs.write_bytes"),
-        ("NFS % of Net IO", "nfs.net_io_pct"),
-        ("Load1", "load.load1"),
-        ("Load per core", "load.load_per_core"),
-        ("Disk usage %", "disk.percent"),
-        ("NFS usage % (avg)", "nfs.usage_percent_avg"),
     ]
-    return [(lbl, col) for lbl, col in candidates if col in df.columns]
+    metrics = [(lbl, col) for lbl, col in base if col in df.columns]
+    for slug, mount in nfs_mounts.items():
+        rb = f"nfs.{slug}.read_bytes"
+        wb = f"nfs.{slug}.write_bytes"
+        if rb in df.columns:
+            metrics.append((f"NFS read {mount} (B/s)", rb))
+        if wb in df.columns:
+            metrics.append((f"NFS write {mount} (B/s)", wb))
+    return metrics
 
 
 # --- Human-readable formatters ---
@@ -293,6 +273,57 @@ def human_rate(n: float) -> str:
         n /= 1024.0
         i += 1
     return f"{n:,.2f} {units[i]}"
+
+
+def human_duration(seconds: float) -> str:
+    if seconds is None or pd.isna(seconds):
+        return "—"
+    seconds = int(seconds)
+    return str(timedelta(seconds=seconds))
+
+
+def print_totals(start: datetime, end: datetime, totals: List[Tuple[str, float]]) -> None:
+    elapsed = (end - start).total_seconds() if start and end else None
+    print("\nTotals (windowed):")
+    print(f"Start:   {start.isoformat()}")
+    print(f"End:     {end.isoformat()}")
+    if elapsed is not None:
+        print(f"Elapsed: {human_duration(elapsed)}")
+    print("metric".ljust(20) + "total")
+    print("-" * 40)
+    for label, value in totals:
+        print(label.ljust(20) + human_bytes(value))
+    print("-" * 40)
+
+
+def print_burstiness(rows: List[Dict[str, Any]]) -> None:
+    if not rows:
+        return
+    headers = [
+        "metric", "PAR", "CV", "P95/mean", "duty_cycle_%",
+        "burst_count", "avg_burst_s", "cadence_s", "cadence_strength",
+    ]
+    widths = [20,8,8,12,14,12,14,12,18]
+    print("\nBurstiness & Cadence:")
+    line = " ".join(h.ljust(w) for h, w in zip(headers, widths))
+    sep = "-" * len(line)
+    print(sep)
+    print(line)
+    print(sep)
+    for row in rows:
+        vals = [
+            row.get("metric", ""),
+            f"{row.get('par', float('nan')):.2f}" if row.get("par") is not None else "—",
+            f"{row.get('cv', float('nan')):.2f}" if row.get("cv") is not None else "—",
+            f"{row.get('p95_over_mean', float('nan')):.2f}" if row.get("p95_over_mean") is not None else "—",
+            f"{row.get('duty_cycle_%', float('nan')):.2f}" if row.get("duty_cycle_%") is not None else "—",
+            f"{int(row.get('burst_count', 0))}" if row.get("burst_count") is not None else "—",
+            f"{row.get('avg_burst_len_s', float('nan')):.2f}" if row.get("avg_burst_len_s") is not None else "—",
+            f"{row.get('cadence_s', float('nan')):.2f}" if row.get("cadence_s") is not None else "—",
+            f"{row.get('cadence_strength', float('nan')):.2f}" if row.get("cadence_strength") is not None else "—",
+        ]
+        print(" ".join(v.ljust(w) for v, w in zip(vals, widths)))
+    print(sep)
 
 def runs_above(arr: np.ndarray, threshold: float) -> tuple[int, list[int]]:
     """Return (burst_count, list_of_burst_lengths_in_samples) for arr > threshold."""
@@ -413,7 +444,7 @@ def main():
         print(f"No data in {path}")
         sys.exit(1)
 
-    df = flatten_columns(df_raw)
+    df, nfs_mounts = flatten_columns(df_raw)
     if df.empty:
         print("No valid rows after parsing.")
         sys.exit(1)
@@ -424,39 +455,39 @@ def main():
     # Estimate sample interval (seconds)
     sample_dt = estimate_sample_dt(dfw.index)
 
+    # Throughput metrics for extras/totals
     throughput_metrics = [
         ("Disk read (B/s)", "disk_io_per_sec.read_bytes"),
         ("Disk write (B/s)", "disk_io_per_sec.write_bytes"),
         ("Net send (B/s)", "net.bytes_sent"),
         ("Net recv (B/s)", "net.bytes_recv"),
-        ("NFS read (B/s)", "nfs.read_bytes"),
-        ("NFS write (B/s)", "nfs.write_bytes"),
     ]
-    extras = {}
+    for slug, mount in nfs_mounts.items():
+        throughput_metrics.append((f"NFS read {mount} (B/s)", f"nfs.{slug}.read_bytes"))
+        throughput_metrics.append((f"NFS write {mount} (B/s)", f"nfs.{slug}.write_bytes"))
 
+    burst_rows: List[Dict[str, Any]] = []
+    totals: List[Tuple[str, float]] = []
     for label, col in throughput_metrics:
         if col in dfw.columns:
             series = dfw[col]
-            extras.update(burst_metrics(label_base(label), series, sample_dt))
+            b = burst_metrics(label_base(label), series, sample_dt)
             cad = detect_cadence(series, sample_dt)
-            extras.update({f"{label_base(label)}_{k}": v for k, v in cad.items()})
+            burst_rows.append({
+                "metric": label,
+                "par": b.get(f"{label_base(label)}_par"),
+                "cv": b.get(f"{label_base(label)}_cv"),
+                "p95_over_mean": b.get(f"{label_base(label)}_p95_over_mean"),
+                "duty_cycle_%": b.get(f"{label_base(label)}_duty_cycle_%"),
+                "burst_count": b.get(f"{label_base(label)}_burst_count"),
+                "avg_burst_len_s": b.get(f"{label_base(label)}_avg_burst_len_s"),
+                "cadence_s": cad.get("cadence_detected_s"),
+                "cadence_strength": cad.get("cadence_autocorr_strength"),
+            })
+            totals.append((label, float(series.fillna(0).sum())))
 
-    # NFS portion of network traffic
-    if {"nfs.read_bytes", "nfs.write_bytes", "net.bytes_sent", "net.bytes_recv"} <= set(dfw.columns):
-        net_send_total = dfw["net.bytes_sent"].fillna(0).sum()
-        net_recv_total = dfw["net.bytes_recv"].fillna(0).sum()
-        nfs_read_total = dfw["nfs.read_bytes"].fillna(0).sum()
-        nfs_write_total = dfw["nfs.write_bytes"].fillna(0).sum()
-        if net_recv_total > 0:
-            extras["nfs_read_pct_of_net_recv_total"] = float(nfs_read_total / net_recv_total * 100.0)
-        if net_send_total > 0:
-            extras["nfs_write_pct_of_net_send_total"] = float(nfs_write_total / net_send_total * 100.0)
-        net_total = net_send_total + net_recv_total
-        if net_total > 0:
-            extras["nfs_total_pct_of_net_total"] = float((nfs_read_total + nfs_write_total) / net_total * 100.0)
-
-    # Build metric list
-    metrics = build_metric_map(dfw)
+    # Build metric list for summary (CPU/mem/net/nfs/swap)
+    metrics = build_metric_map(dfw, nfs_mounts)
 
     # Summaries
     rows = []
@@ -465,25 +496,24 @@ def main():
         th = THRESHOLDS.get(label)
         rows.append(summarize_series(label, series, th, sample_dt))
 
-        # Extra throughput aggregates for bytes/sec metrics
-        if label in {"Disk read (B/s)", "Disk write (B/s)", "Net send (B/s)", "Net recv (B/s)", "NFS read (B/s)", "NFS write (B/s)"}:
-            extras.update(summarize_throughput(label_base(label), series, sample_dt))
-
-    # Assemble DataFrame for nice printing and saving
     df_rows = pd.DataFrame(rows)
-
     print_table(df_rows)
 
-    print("\nBurstiness & Cadence:")
-    for k, v in extras.items():
-        print(f"{k}: {v}")
+    # Totals window
+    if isinstance(dfw.index, pd.DatetimeIndex) and not dfw.index.empty:
+        start, end = dfw.index.min(), dfw.index.max()
+        print_totals(start, end, totals)
+
+    # Burstiness table
+    print_burstiness(burst_rows)
 
     # Save JSON + CSV with extras
     output = {
         "window_minutes": WINDOW_MINUTES,
         "sample_interval_seconds_est": sample_dt,
         "metrics": rows,
-        "extras": extras,
+        "totals": totals,
+        "burstiness": burst_rows,
     }
     Path(OUT_JSON).write_text(json.dumps(output, indent=2), encoding="utf-8")
     df_rows.to_csv(OUT_CSV, index=False)


### PR DESCRIPTION
## Summary
- rewrite summarizer to report only CPU, memory, swap, net I/O, and per-mount NFS I/O
- add totals section with start/end timestamps and human-readable byte totals
- format burstiness & cadence metrics in a dedicated table

## Testing
- `python summary_vm_stats.py` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_689b5e59796c8326879618848fd44f57